### PR TITLE
give sftpuser access to home folder

### DIFF
--- a/sftp-server/src/charm.py
+++ b/sftp-server/src/charm.py
@@ -56,8 +56,7 @@ class SftpServerCharm(CharmBase):
         os.system(f"adduser sftpuser --ingroup sftpaccess --home /srv/sftpuser --no-create-home --shell  /usr/sbin/nologin --disabled-password --gecos ''")
         os.system(f"mkdir -p {userHome}/.ssh")
         os.system(f"chmod 0700 {userHome}/.ssh")
-        os.system(f"chown root.root {userHome}")
-        os.system(f"chown -R sftpuser.sftpaccess {userHome}/.ssh")
+        os.system(f"chown -R sftpuser.sftpaccess {userHome}")
 
         # Install the restricted-ssh-command package that helps with scp-only-ssh-feature
         shutil.copyfile('templates/etc/ssh/sshd_config',


### PR DESCRIPTION
I had to manually ssh to the instance and create a directory that the sftpuser has access to. Why not just give the sftpuser access to its home directory so that the user can directly start putting stuff there?