### PR TITLE
Add multiple rsa keys. Create data directory.

### DIFF
--- a/sftp-server/README.md
+++ b/sftp-server/README.md
@@ -39,7 +39,7 @@ Remote client that wish to copy data to the remote unit creates its ssh key pair
 
 The juju operator adds the public key to the unit with a juju action:
 
-    juju run-action sftp-server/0 set-ssh-key key="$(cat ~/myscp_rsa.pub)" --wait
+    juju run-action sftp-server/0 add-ssh-key key="$(cat ~/myscp_rsa.pub)" --wait
 
 The remote client can now copy data to the data location using the scponly user:
 

--- a/sftp-server/README.md
+++ b/sftp-server/README.md
@@ -3,7 +3,7 @@ This charm enables sftp for a sftpuser but restricts ssh login.
 
 The operator uses an action to deploy a public key to be used as the authentication mechanism.
 
-The charm supports using [juju storage] for persistent storage at */srv/onlyscp/data*
+The charm supports using [juju storage] for persistent storage at */srv/sftpuser*
 
 ## Usage
 
@@ -41,9 +41,10 @@ The juju operator adds the public key to the unit with a juju action:
 
     juju run-action sftp-server/0 add-ssh-key key="$(cat ~/myscp_rsa.pub)" --wait
 
-The remote client can now copy data to the data location using the scponly user:
+The remote client can now copy data to the data location using the sftpuser user:
 
     sftp -i ./myscp_rsa sftpuser@192.168.2.144
+    put /path/to/file data
 
 
 ## Authors

--- a/sftp-server/actions.yaml
+++ b/sftp-server/actions.yaml
@@ -1,5 +1,5 @@
-set-ssh-key:
-  description: "Update/set the public key for user scponly user."
+add-ssh-key:
+  description: "Add a public key as authorized for the sftpuser."
   params:
     key:
       decription: "Public key"

--- a/sftp-server/src/charm.py
+++ b/sftp-server/src/charm.py
@@ -30,7 +30,7 @@ class SftpServerCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.upgrade_charm, self._on_upgrade_charm)
-        self.framework.observe(self.on.set_ssh_key_action, self._on_set_ssh_key_action)
+        self.framework.observe(self.on.add_ssh_key_action, self._on_add_ssh_key_action)
 
     def _on_data_storage_attached(self, event):
         """
@@ -74,10 +74,10 @@ class SftpServerCharm(CharmBase):
         """
             Let the user know that a ssh-key is needed to properly set this charm up to serve scp.
         """
-        logger.info("Add public ssh key with action: set-ssh-key")
-        self.unit.status = WaitingStatus("Waiting on set-ssh-key action.")
+        logger.info("Add public ssh key with action: add-ssh-key")
+        self.unit.status = WaitingStatus("Waiting on add-ssh-key action.")
 
-    def _on_set_ssh_key_action(self, event):
+    def _on_add_ssh_key_action(self, event):
         userHome = Path(self.model.storages['data'][0].location)
         key = event.params['key']
         check_key = True
@@ -85,8 +85,8 @@ class SftpServerCharm(CharmBase):
             event.fail("Illegal key entered.")
         else:
             os.system(f"mkdir -p {userHome}/.ssh/")
-            file = open(f"{userHome}/.ssh/authorized_keys", "w+")
-            file.write(key)
+            file = open(f"{userHome}/.ssh/authorized_keys", "a")
+            file.write(key + '\n')
             file.close()
             os.system(f"chown sftpuser.sftpaccess {userHome}/.ssh/authorized_keys")
             os.system(f"chmod 0600 {userHome}/.ssh/authorized_keys")

--- a/sftp-server/src/charm.py
+++ b/sftp-server/src/charm.py
@@ -54,10 +54,10 @@ class SftpServerCharm(CharmBase):
 
         os.system('groupadd sftpaccess')
         os.system(f"adduser sftpuser --ingroup sftpaccess --home /srv/sftpuser --no-create-home --shell  /usr/sbin/nologin --disabled-password --gecos ''")
-        os.system(f"mkdir -p {userHome}/.ssh")
+        os.system(f"mkdir -p {userHome}/.ssh {userHome}/data")
+        os.system(f"chown -R sftpuser.sftpaccess {userHome}/.ssh {userHome}/data")
         os.system(f"chmod 0700 {userHome}/.ssh")
-        os.system(f"chown root.root {userHome}")
-        os.system(f"chown -R sftpuser.sftpaccess {userHome}/.ssh")
+        os.system(f"chown root.root {userHome}") # sftpuser home directory must be owned by root for sftp access to work.
 
         # Install the restricted-ssh-command package that helps with scp-only-ssh-feature
         shutil.copyfile('templates/etc/ssh/sshd_config',


### PR DESCRIPTION
* set-ssh-key -> add-ssh-key: Append key to authorizedkeys instead of overwrite so multiple keys can be added.
* Automatically create data directory to put to. Otherwise operator needs to ssh to the instance and create it manually.